### PR TITLE
Make README install section more complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ Clone the repository:
 
     git clone git@github.com:mapbox/docshot.git
 
-Open Chrome settings, browse to "Extensions", and select "Load unpacked extension":
+Open Chrome settings, browse to "Extensions", make sure the "Developer mode"
+checkbox is selected, and select "Load unpacked extension":
 
 ![Load extension](http://i.imgur.com/v69GizR.png)
 
-Browse to the `docshot` cloned repository directory and select it to add the link to Chrome's main toolbar.
+Browse to the `docshot` cloned repository directory and select it to add the
+link to Chrome's main toolbar.


### PR DESCRIPTION
Mentions that developer mode has to be enabled in order to see the "Load
unpacked extension" button.
